### PR TITLE
fix: update service name and prevent terraform issue

### DIFF
--- a/terraform/groups/fidc-monitoring/main.tf
+++ b/terraform/groups/fidc-monitoring/main.tf
@@ -112,7 +112,7 @@ module "mappings_monitoring" {
 
 module "grafana" {
   source                = "./modules/grafana"
-  service_name          = var.service_name
+  service_name          = "forgerock"
   vpc_id                = data.aws_vpc.vpc.id
   subnet_ids            = data.aws_subnet_ids.subnets.ids
   instance_type         = var.grafana_instance_type
@@ -128,7 +128,7 @@ module "grafana" {
 
 module "prometheus" {
   source                = "./modules/prometheus"
-  service_name          = var.service_name
+  service_name          = "forgerock"
   vpc_id                = data.aws_vpc.vpc.id
   subnet_ids            = data.aws_subnet_ids.subnets.ids
   instance_type         = var.prometheus_instance_type

--- a/terraform/groups/fidc-monitoring/modules/ecs/main.tf
+++ b/terraform/groups/fidc-monitoring/modules/ecs/main.tf
@@ -22,7 +22,9 @@ resource "aws_security_group" "ecs_tasks" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    Name = var.service_name
+  })
 }
 
 data "aws_iam_policy_document" "ecs_task_execution_role" {

--- a/terraform/groups/fidc-monitoring/modules/grafana/loadbalancing.tf
+++ b/terraform/groups/fidc-monitoring/modules/grafana/loadbalancing.tf
@@ -134,5 +134,7 @@ resource "aws_security_group" "grafana_lb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    Name = "${var.service_name}-grafana-lb"
+  })
 }

--- a/terraform/groups/fidc-monitoring/modules/grafana/main.tf
+++ b/terraform/groups/fidc-monitoring/modules/grafana/main.tf
@@ -34,7 +34,9 @@ resource "aws_security_group" "instance" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    Name = "${var.service_name}-grafana-instance"
+  })
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/groups/fidc-monitoring/modules/grafana/main.tf
+++ b/terraform/groups/fidc-monitoring/modules/grafana/main.tf
@@ -15,7 +15,7 @@ data "aws_ami" "grafana" {
 
 resource "aws_security_group" "instance" {
   description = "Restricts access to grafana ${var.service_name} instance"
-  name        = "${var.service_name}-grafana-instance"
+  name_prefix = "${var.service_name}-grafana-instance-"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -35,6 +35,10 @@ resource "aws_security_group" "instance" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_instance" "grafana" {

--- a/terraform/groups/fidc-monitoring/modules/prometheus/loadbalancing.tf
+++ b/terraform/groups/fidc-monitoring/modules/prometheus/loadbalancing.tf
@@ -133,5 +133,7 @@ resource "aws_security_group" "prometheus_lb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    Name = "${var.service_name}-prometheus-lb"
+  })
 }

--- a/terraform/groups/fidc-monitoring/modules/prometheus/main.tf
+++ b/terraform/groups/fidc-monitoring/modules/prometheus/main.tf
@@ -15,7 +15,7 @@ data "aws_ami" "prometheus" {
 
 resource "aws_security_group" "instance" {
   description = "Restricts access to prometheus ${var.service_name} instance"
-  name        = "${var.service_name}-prometheus-instance"
+  name_prefix = "${var.service_name}-prometheus-instance-"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -35,6 +35,10 @@ resource "aws_security_group" "instance" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_instance" "prometheus" {

--- a/terraform/groups/fidc-monitoring/modules/prometheus/main.tf
+++ b/terraform/groups/fidc-monitoring/modules/prometheus/main.tf
@@ -34,7 +34,9 @@ resource "aws_security_group" "instance" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = var.tags
+  tags = merge(var.tags, {
+    Name = "${var.service_name}-prometheus-instance"
+  })
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
The last Live release failed due to the service_name exceeding the character limit.

After addressing this in the pipeline for the release, Terraform attempted to remove security groups before the instances and failed.