### PR TITLE
Idam 1418 restart logging containers schedule

### DIFF
--- a/terraform/groups/chs/main.tf
+++ b/terraform/groups/chs/main.tf
@@ -62,6 +62,7 @@ module "idm_logging" {
   tags                       = local.common_tags
   log_source                 = "idm"
   log_frequency              = 10
+  restart_frequency_schedule = "cron(0 2 * * * *)"
 }
 
 module "am_logging" {

--- a/terraform/groups/chs/modules/ecs-restart-lambda/eventbridge.tf
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/eventbridge.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_event_rule" "invoker" {
+    name = "invoke_restart_${var.ecs_cluster_arn}_${var.ecs_service_name}"
+    description = "Trigger restart of ${var.ecs_service_name} svc on ECS cluster ${var.ecs_cluster_arn}"
+    schedule_expression = var.restart_frequency_schedule
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+    rule = aws_cloudwatch_event_rule.invoker.name
+    target_id = "InvokeLambda"
+    arn = aws_lambda_function.restart_function.arn
+}

--- a/terraform/groups/chs/modules/ecs-restart-lambda/iam.tf
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/iam.tf
@@ -1,0 +1,54 @@
+locals {
+    service_arn = "arn:aws:ecs:"
+}
+
+resource "aws_iam_role" "execution_role" {
+    name = "restart_ecs_service_${var.ecs_cluster_name}_${var.ecs_service_name}"
+
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+    EOF
+}
+
+resource "aws_iam_role_policy" "policy" {
+    name = "grant_lambda_access_to_restart_ecs_service_${var.ecs_cluster_name}_${var.ecs_service_name}"
+    role = aws_iam_role.execution_role
+    policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [{
+            Action = [
+                "ecs:UpdateService"
+            ]
+            Effect = "Allow"
+            Resource = [
+                var.ecs_service_arn
+            ]
+        }]
+    })
+}
+
+resource "aws_lambda_permission" "eventbridge" {
+    statement_id = "AllowEventBridgeToExecute"
+    action = "lambda:InvokeFunction"
+    function_name = aws_lambda_function.restart_function.function_name
+    principal = "events.amazonaws.com"
+    qualifier = aws_lambda_alias.alias.name
+}
+
+resource "aws_lambda_alias" "alias" {
+    name = "alias_restart_ecs_service_${var.ecs_cluster_name}_${var.ecs_service_name}"
+    function_name = aws_lambda_function.restart_function.function_name
+    function_version = "$LATEST"
+}

--- a/terraform/groups/chs/modules/ecs-restart-lambda/lambda.tf
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/lambda.tf
@@ -1,0 +1,16 @@
+resource "aws_lambda_function" "restart_function" {
+    filename = "ecs_service_restart.zip"
+    function_name = "ecs_service_restart_${var.ecs_cluster_name}_${var.ecs_service_name}"
+    role = aws_iam_role.execution_role
+    handler = "index.main"
+
+    source_code_hash = filebase64sha256("ecs_service_restart.zip")
+    runtime = "nodejs12.x"
+
+    environment {
+        variables = {
+            ecs_cluster_arn = var.ecs_cluster_arn
+            ecs_service_name = var.ecs_service_name
+        }
+    }
+}

--- a/terraform/groups/chs/modules/ecs-restart-lambda/lambda_code/index.js
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/lambda_code/index.js
@@ -1,0 +1,12 @@
+const AWS = require('aws-sdk');
+
+exports.main = async function(event, context) {
+    const ecs = new AWS.ECS();
+    ecs.UpdateService({
+        cluster: process.env.ecs_cluster_arn,
+        service: process.env.ecs_cluster_name,
+        forceNewDeployment: true
+    }).catch(error => {
+            throw error;
+        });
+}

--- a/terraform/groups/chs/modules/ecs-restart-lambda/variables.tf
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/variables.tf
@@ -1,0 +1,15 @@
+variable "ecs_cluster_arn" {
+    type = string
+}
+
+variable "ecs_service_arn" {
+    type = string
+}
+
+variable "ecs_service_name" {
+    type = string
+}
+
+variable "restart_frequency_schedule" {
+    type = string
+}

--- a/terraform/groups/chs/modules/ecs-task/main.tf
+++ b/terraform/groups/chs/modules/ecs-task/main.tf
@@ -42,3 +42,12 @@ resource "aws_ecs_service" "monitoring" {
 
   tags = var.tags
 }
+
+module "restarter_lambda" {
+  source = "../ecs-restart-lambda"
+
+  ecs_cluster_arn = var.ecs_cluster_id
+  ecs_service_arn = aws_ecs_service.monitoring.arn
+  ecs_service_name = var.task_name
+  restart_frequency_schedule = var.restart_frequency_schedule
+}

--- a/terraform/groups/chs/modules/ecs-task/variables.tf
+++ b/terraform/groups/chs/modules/ecs-task/variables.tf
@@ -75,3 +75,8 @@ variable "log_frequency" {
   description = "Rate, in seconds, at which logs should be retrieved from FIDC"
   default = 10
 }
+
+variable "restart_frequency_schedule" {
+  type = string
+  description = "Cron schedule on which to execute the restart"
+}

--- a/terraform/groups/chs/modules/ecs/outputs.tf
+++ b/terraform/groups/chs/modules/ecs/outputs.tf
@@ -9,3 +9,7 @@ output "task_role_arn" {
 output "task_security_group_id" {
   value = aws_security_group.ecs_tasks.id
 }
+
+output "cluster_name" {
+  value = aws_ecs_cluster.monitoring.name
+}


### PR DESCRIPTION
Creates a lambda designed to force a redeployment (i.e. a restart) of a parent ECS logging container on an Eventbridge schedule.