### PR TITLE
Implement Prefix Lists

### DIFF
--- a/terraform/groups/chs/provider.tf
+++ b/terraform/groups/chs/provider.tf
@@ -9,15 +9,6 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "networking" {
-  backend = "s3"
-  config = {
-    bucket = "${var.environment}-${var.region}.terraform-state.ch.gov.uk"
-    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
-    region = var.region
-  }
-}
-
 provider "aws" {
   region = var.region
 }

--- a/terraform/groups/grafana/locals.tf
+++ b/terraform/groups/grafana/locals.tf
@@ -9,7 +9,6 @@ locals {
   concourse_worker_cidrs = jsondecode(local.secrets.concourse_worker_cidrs)
   dns_zone_name = local.secrets.dns_zone_name
   grafana_admin_password = local.secrets.grafana_admin_password
-  internal_cidrs = values(data.terraform_remote_state.networking.outputs.internal_cidrs)
   ldap_auth_bind_dn = local.secrets.ldap_auth_bind_dn
   ldap_auth_bind_password = local.secrets.ldap_auth_bind_password
   ldap_auth_host = local.secrets.ldap_auth_host
@@ -24,11 +23,7 @@ locals {
   ssh_keyname = "${var.service}-${var.environment}.pem"
   vpc_id = data.aws_vpc.vpc.id
   vpc_name = local.secrets.vpc_name
-  vpn_cidrs = values(data.terraform_remote_state.networking.outputs.vpn_cidrs)
 
-  administration_cidrs = concat(local.internal_cidrs, local.vpn_cidrs)
   placement_subnet_ids = [for subnet in values(data.aws_subnet.placement) : lookup(subnet, "id")]
   placement_subnet_ids_by_availability_zone = values(zipmap(local.placement_subnet_availability_zones, local.placement_subnet_ids))
-
-  grafana_cidrs = concat(local.administration_cidrs, local.concourse_worker_cidrs)
 }

--- a/terraform/groups/grafana/main.tf
+++ b/terraform/groups/grafana/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.region
-  version = "~> 2.0"
+  version = "~> 3.0"
 }
 
 terraform {
@@ -10,6 +10,7 @@ terraform {
 module "grafana" {
   source = "./module-grafana"
 
+  admin_prefix_list_id          = data.aws_ec2_managed_prefix_list.admin_cidrs.id
   ami_owner_id                  = var.ami_owner_id
   ami_version_pattern           = var.grafana_ami_version_pattern
   certificate_arn               = local.certificate_arn

--- a/terraform/groups/grafana/main.tf
+++ b/terraform/groups/grafana/main.tf
@@ -1,10 +1,21 @@
-provider "aws" {
-  region  = var.region
-  version = "~> 3.0"
+terraform {
+  required_version = ">= 0.13.0, < 0.14.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 2.0"
+    }
+  }
+  backend "s3" {}
 }
 
-terraform {
-  backend "s3" {}
+provider "aws" {
+  region = var.region
 }
 
 module "grafana" {

--- a/terraform/groups/grafana/main.tf
+++ b/terraform/groups/grafana/main.tf
@@ -29,7 +29,7 @@ module "grafana" {
   environment                   = var.environment
   instance_count                = var.grafana_instance_count
   instance_type                 = var.grafana_instance_type
-  grafana_cidrs                 = local.grafana_cidrs
+  grafana_cidrs                 = local.concourse_worker_cidrs
   grafana_service_group         = var.grafana_service_group
   grafana_service_user          = var.grafana_service_user
   grafana_admin_password        = local.grafana_admin_password
@@ -50,7 +50,6 @@ module "grafana" {
   root_volume_size              = var.grafana_root_volume_size
   route53_available             = local.route53_available
   service                       = var.service
-  ssh_cidrs                     = local.administration_cidrs
   ssh_keyname                   = local.ssh_keyname
   subnet_ids                    = local.placement_subnet_ids_by_availability_zone
   user_data_merge_strategy      = var.user_data_merge_strategy

--- a/terraform/groups/grafana/module-grafana/alb.tf
+++ b/terraform/groups/grafana/module-grafana/alb.tf
@@ -10,7 +10,7 @@ resource "aws_acm_certificate_validation" "certificate" {
   count                   = var.route53_available ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.certificate[0].arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
 }
 
 resource "aws_lb" "grafana" {

--- a/terraform/groups/grafana/module-grafana/locals.tf
+++ b/terraform/groups/grafana/module-grafana/locals.tf
@@ -5,4 +5,6 @@ locals {
       block_device if block_device.device_name != data.aws_ami.grafana.root_device_name
   ]
   certificate_arn = var.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : var.certificate_arn
+
+  acm_certificate_domain_validation_options = var.route53_available ? aws_acm_certificate.certificate[0].domain_validation_options : {}
 }

--- a/terraform/groups/grafana/module-grafana/locals.tf
+++ b/terraform/groups/grafana/module-grafana/locals.tf
@@ -6,5 +6,13 @@ locals {
   ]
   certificate_arn = var.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : var.certificate_arn
 
-  acm_certificate_domain_validation_options = var.route53_available ? aws_acm_certificate.certificate[0].domain_validation_options : {}
+  acm_certificate_domain_validation_options = (
+    var.route53_available ? {
+      for dvo in aws_acm_certificate.certificate[0].domain_validation_options : dvo.domain_name => {
+        name    = dvo.resource_record_name
+        type    = dvo.resource_record_type
+        records = [dvo.resource_record_value]
+      }
+    } : {}
+  )
 }

--- a/terraform/groups/grafana/module-grafana/route53.tf
+++ b/terraform/groups/grafana/module-grafana/route53.tf
@@ -16,13 +16,7 @@ resource "aws_route53_record" "grafana" {
 }
 
 resource "aws_route53_record" "certificate_validation" {
-  for_each = {
-    for dvo in local.acm_certificate_domain_validation_options : dvo.domain_name => {
-      name    = dvo.resource_record_name
-      type    = dvo.resource_record_type
-      records = [dvo.resource_record_value]
-    } if var.route53_available
-  }
+  for_each = local.acm_certificate_domain_validation_options
 
   allow_overwrite = true
   zone_id         = data.aws_route53_zone.zone[0].zone_id

--- a/terraform/groups/grafana/module-grafana/route53.tf
+++ b/terraform/groups/grafana/module-grafana/route53.tf
@@ -16,13 +16,20 @@ resource "aws_route53_record" "grafana" {
 }
 
 resource "aws_route53_record" "certificate_validation" {
-  count   = var.route53_available ? 1 : 0
+  for_each = {
+    for dvo in local.acm_certificate_domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      records = [dvo.resource_record_value]
+    } if var.route53_available
+  }
 
-  zone_id = data.aws_route53_zone.zone[0].zone_id
-  name    = aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_type
-  records = [aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_value]
-  ttl     = 60
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.zone[0].zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = each.value.records
+  ttl             = 60
 }
 
 

--- a/terraform/groups/grafana/module-grafana/security-groups.tf
+++ b/terraform/groups/grafana/module-grafana/security-groups.tf
@@ -41,11 +41,12 @@ resource "aws_security_group" "grafana_load_balancer" {
   vpc_id = var.vpc_id
 
   ingress {
-    description = "Grafana"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.grafana_cidrs
+    description     = "Grafana"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks     = var.grafana_cidrs
+    prefix_list_ids = [var.admin_prefix_list_id]
   }
 
   egress {

--- a/terraform/groups/grafana/module-grafana/security-groups.tf
+++ b/terraform/groups/grafana/module-grafana/security-groups.tf
@@ -4,18 +4,18 @@ resource "aws_security_group" "grafana_instances" {
   vpc_id = var.vpc_id
 
   ingress {
-    description = "Inbound SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.ssh_cidrs
+    description     = "Inbound SSH"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    prefix_list_ids = [var.admin_prefix_list_id]
   }
 
   ingress {
-    description = "Grafana"
-    from_port   = 3000
-    to_port     = 3000
-    protocol    = "tcp"
+    description     = "Grafana"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
     security_groups = [aws_security_group.grafana_load_balancer.id]
   }
 

--- a/terraform/groups/grafana/module-grafana/variables.tf
+++ b/terraform/groups/grafana/module-grafana/variables.tf
@@ -1,3 +1,8 @@
+variable "admin_prefix_list_id" {
+  type        = string
+  description = "Resource ID for the prefix list containing administrative CIDRs"
+}
+
 variable "ami_owner_id" {
   type        = string
   description = "The ID of the AMI owner"

--- a/terraform/groups/grafana/module-grafana/variables.tf
+++ b/terraform/groups/grafana/module-grafana/variables.tf
@@ -148,11 +148,6 @@ variable "service" {
   type        = string
 }
 
-variable "ssh_cidrs" {
-  description = "The SSH of the CIDR to be used"
-  type = list(string)
-}
-
 variable "ssh_keyname" {
   description = "The SSH keypair name to use for remote connectivity"
   type        = string

--- a/terraform/groups/grafana/prefix-lists.tf
+++ b/terraform/groups/grafana/prefix-lists.tf
@@ -1,0 +1,6 @@
+data "aws_ec2_managed_prefix_list" "admin_cidrs" {
+  filter {
+    name   = "prefix-list-name"
+    values = [var.admin_cidrs_prefix_list_name]
+  }
+}

--- a/terraform/groups/grafana/remote-state.tf
+++ b/terraform/groups/grafana/remote-state.tf
@@ -1,8 +1,0 @@
-data "terraform_remote_state" "networking" {
-  backend = "s3"
-  config = {
-    bucket = "${var.account_name}-${var.region}.terraform-state.ch.gov.uk"
-    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
-    region = var.region
-  }
-}

--- a/terraform/groups/grafana/variables.tf
+++ b/terraform/groups/grafana/variables.tf
@@ -3,6 +3,12 @@ variable "account_name" {
   type        = string
 }
 
+variable "admin_cidrs_prefix_list_name" {
+  default     = "administration-cidr-ranges"
+  description = "Name of the prefix list containing administration cidrs"
+  type        = string
+}
+
 variable "ami_owner_id" {
   type        = string
   description = "The ID of the AMI owner"

--- a/terraform/groups/prometheus/locals.tf
+++ b/terraform/groups/prometheus/locals.tf
@@ -8,19 +8,14 @@ locals {
   certificate_arn = contains(keys(local.secrets), "certificate_arn") ? local.secrets.certificate_arn : null
   discovery_availability_zones = join(",", list("${var.region}a", "${var.region}b", "${var.region}c"))
   dns_zone_name = local.secrets.dns_zone_name
-  internal_cidrs = values(data.terraform_remote_state.networking.outputs.internal_cidrs)
   placement_subnet_availability_zones = [for subnet in values(data.aws_subnet.placement) : lookup(subnet, "availability_zone")]
   placement_subnet_name_patterns = jsondecode(local.secrets.placement_subnet_name_patterns)
   route53_available = local.secrets.route53_available
   ssh_keyname = "${var.service}-${var.environment}.pem"
   vpc_id = data.aws_vpc.vpc.id
   vpc_name = local.secrets.vpc_name
-  vpn_cidrs = values(data.terraform_remote_state.networking.outputs.vpn_cidrs)
 
-  administration_cidrs = concat(local.internal_cidrs, local.vpn_cidrs)
   placement_subnet_ids = [for subnet in values(data.aws_subnet.placement) : subnet.id]
   placement_subnet_cidrs = [for subnet in values(data.aws_subnet.placement) : subnet.cidr_block]
   placement_subnet_ids_by_availability_zone = values(zipmap(local.placement_subnet_availability_zones, local.placement_subnet_ids))
-
-  prometheus_cidrs = concat(local.administration_cidrs, local.placement_subnet_cidrs)
 }

--- a/terraform/groups/prometheus/main.tf
+++ b/terraform/groups/prometheus/main.tf
@@ -1,15 +1,27 @@
-provider "aws" {
-  region  = var.region
-  version = "~> 2.0"
+terraform {
+  required_version = ">= 0.13.0, < 0.14.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 2.0"
+    }
+  }
+  backend "s3" {}
 }
 
-terraform {
-  backend "s3" {}
+provider "aws" {
+  region = var.region
 }
 
 module "prometheus" {
   source = "./module-prometheus"
 
+  admin_prefix_list_id          = data.aws_ec2_managed_prefix_list.admin_cidrs.id
   ami_owner_id                  = var.ami_owner_id
   ami_version_pattern           = var.prometheus_ami_version_pattern
   certificate_arn               = local.certificate_arn
@@ -18,7 +30,7 @@ module "prometheus" {
   environment                   = var.environment
   instance_count                = var.prometheus_instance_count
   instance_type                 = var.prometheus_instance_type
-  prometheus_cidrs              = local.prometheus_cidrs
+  prometheus_cidrs              = local.placement_subnet_cidrs
   prometheus_service_group      = var.prometheus_service_group
   prometheus_service_user       = var.prometheus_service_user
   lvm_block_devices             = var.prometheus_lvm_block_devices
@@ -28,7 +40,6 @@ module "prometheus" {
   root_volume_size              = var.prometheus_root_volume_size
   route53_available             = local.route53_available
   service                       = var.service
-  ssh_cidrs                     = local.administration_cidrs
   ssh_keyname                   = local.ssh_keyname
   subnet_ids                    = local.placement_subnet_ids_by_availability_zone
   user_data_merge_strategy      = var.user_data_merge_strategy

--- a/terraform/groups/prometheus/module-prometheus/alb.tf
+++ b/terraform/groups/prometheus/module-prometheus/alb.tf
@@ -10,7 +10,7 @@ resource "aws_acm_certificate_validation" "certificate" {
   count                   = var.route53_available ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.certificate[0].arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
 }
 
 resource "aws_lb" "prometheus" {

--- a/terraform/groups/prometheus/module-prometheus/locals.tf
+++ b/terraform/groups/prometheus/module-prometheus/locals.tf
@@ -5,4 +5,14 @@ locals {
       block_device if block_device.device_name != data.aws_ami.prometheus.root_device_name
   ]
   certificate_arn = var.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : var.certificate_arn
+
+  acm_certificate_domain_validation_options = (
+    var.route53_available ? {
+      for dvo in aws_acm_certificate.certificate[0].domain_validation_options : dvo.domain_name => {
+        name    = dvo.resource_record_name
+        type    = dvo.resource_record_type
+        records = [dvo.resource_record_value]
+      }
+    } : {}
+  )
 }

--- a/terraform/groups/prometheus/module-prometheus/route53.tf
+++ b/terraform/groups/prometheus/module-prometheus/route53.tf
@@ -16,13 +16,14 @@ resource "aws_route53_record" "prometheus" {
 }
 
 resource "aws_route53_record" "certificate_validation" {
-  count   = var.route53_available ? 1 : 0
+  for_each = local.acm_certificate_domain_validation_options
 
-  zone_id = data.aws_route53_zone.zone[0].zone_id
-  name    = aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_type
-  records = [aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_value]
-  ttl     = 60
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.zone[0].zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = each.value.records
+  ttl             = 60
 }
 
 resource "aws_route53_record" "prometheus_load_balancer" {

--- a/terraform/groups/prometheus/module-prometheus/security-groups.tf
+++ b/terraform/groups/prometheus/module-prometheus/security-groups.tf
@@ -4,18 +4,18 @@ resource "aws_security_group" "prometheus" {
   vpc_id = var.vpc_id
 
   ingress {
-    description = "Inbound SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.ssh_cidrs
+    description     = "Inbound SSH"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    prefix_list_ids = [var.admin_prefix_list_id]
   }
 
   ingress {
-    description = "Prometheus"
-    from_port   = 9090
-    to_port     = 9090
-    protocol    = "tcp"
+    description     = "Prometheus"
+    from_port       = 9090
+    to_port         = 9090
+    protocol        = "tcp"
     security_groups = [aws_security_group.prometheus_load_balancer.id]
   }
 
@@ -41,11 +41,12 @@ resource "aws_security_group" "prometheus_load_balancer" {
   vpc_id = var.vpc_id
 
   ingress {
-    description = "Prometheus"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.prometheus_cidrs
+    description     = "Prometheus"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks     = var.prometheus_cidrs
+    prefix_list_ids = [var.admin_prefix_list_id]
   }
 
   egress {

--- a/terraform/groups/prometheus/module-prometheus/variables.tf
+++ b/terraform/groups/prometheus/module-prometheus/variables.tf
@@ -1,3 +1,8 @@
+variable "admin_prefix_list_id" {
+  type        = string
+  description = "Resource ID for the prefix list containing administrative CIDRs"
+}
+
 variable "ami_owner_id" {
   type        = string
   description = "The ID of the AMI owner"
@@ -91,11 +96,6 @@ variable "route53_available" {
 variable "service" {
   description = "The service name to be used when creating AWS resources"
   type        = string
-}
-
-variable "ssh_cidrs" {
-  description = "The SSH of the CIDR to be used"
-  type = list(string)
 }
 
 variable "ssh_keyname" {

--- a/terraform/groups/prometheus/prefix-lists.tf
+++ b/terraform/groups/prometheus/prefix-lists.tf
@@ -1,0 +1,6 @@
+data "aws_ec2_managed_prefix_list" "admin_cidrs" {
+  filter {
+    name   = "prefix-list-name"
+    values = [var.admin_cidrs_prefix_list_name]
+  }
+}

--- a/terraform/groups/prometheus/remote-state.tf
+++ b/terraform/groups/prometheus/remote-state.tf
@@ -1,8 +1,0 @@
-#data "terraform_remote_state" "networking" {
-#  backend = "s3"
-#  config = {
-#    bucket = "${var.account_name}-${var.region}.terraform-state.ch.gov.uk"
-#    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
-#    region = var.region
-#  }
-#}

--- a/terraform/groups/prometheus/remote-state.tf
+++ b/terraform/groups/prometheus/remote-state.tf
@@ -1,8 +1,8 @@
-data "terraform_remote_state" "networking" {
-  backend = "s3"
-  config = {
-    bucket = "${var.account_name}-${var.region}.terraform-state.ch.gov.uk"
-    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
-    region = var.region
-  }
-}
+#data "terraform_remote_state" "networking" {
+#  backend = "s3"
+#  config = {
+#    bucket = "${var.account_name}-${var.region}.terraform-state.ch.gov.uk"
+#    key    = "aws-common-infrastructure-terraform/common-${var.region}/networking.tfstate"
+#    region = var.region
+#  }
+#}

--- a/terraform/groups/prometheus/variables.tf
+++ b/terraform/groups/prometheus/variables.tf
@@ -3,6 +3,12 @@ variable "account_name" {
   type        = string
 }
 
+variable "admin_cidrs_prefix_list_name" {
+  default     = "administration-cidr-ranges"
+  description = "Name of the prefix list containing administration cidrs"
+  type        = string
+}
+
 variable "ami_owner_id" {
   type        = string
   description = "The ID of the AMI owner"


### PR DESCRIPTION
### `grafana` group
Bumped `aws` provider to `~> 3.0`
Added supporting vars and data lookup for admin prefix list
Updated module config to pass prefix data through
Reworked route53 and acm resources for new data structure introduced by the updated provider
Added local var to support new behaviour
Removed deprecated remote state data
Updated vars previously relying on remote state data

### `prometheus` group
Bumped `aws` provider to `~> 3.0`
Added supporting vars and data lookup for admin prefix list
Updated module config to pass prefix data through
Reworked route53 and acm resources for new data structure introduced by the updated provider
Added local var to support new behaviour
Removed deprecated remote state data
Updated vars previously relying on remote state data

### `chs` group
Removed reference to unused data source