### PR TITLE
MS1-582 Update CloudFormation runtime version

### DIFF
--- a/terraform/groups/chs/main.tf
+++ b/terraform/groups/chs/main.tf
@@ -97,7 +97,7 @@ module "rcs_monitoring" {
   canary_name              = "fr-rcs"
   release_version          = var.container_image_version
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   source_code_path         = "${path.module}/scripts/rcs-monitoring"
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
@@ -124,7 +124,7 @@ module "mapping_chscompany" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -150,7 +150,7 @@ module "mapping_wfauthcode" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -176,7 +176,7 @@ module "mapping_wfuser" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -202,7 +202,7 @@ module "connector_chscompany" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -228,7 +228,7 @@ module "connector_wfauthcode" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -254,7 +254,7 @@ module "connector_wfuser" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -280,7 +280,7 @@ module "duration_chscompany" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -306,7 +306,7 @@ module "duration_wfauthcode" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -332,7 +332,7 @@ module "duration_wfuser" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn
@@ -358,7 +358,7 @@ module "cancelRecon" {
   release_version          = var.container_image_version
   source_code_path         = "${path.module}/scripts/mappings-monitoring"
   handler                  = "index.handler"
-  runtime_version          = "syn-nodejs-puppeteer-3.9"
+  runtime_version          = "syn-nodejs-puppeteer-9.0"
   release_bucket           = var.release_bucket
   artifact_bucket          = module.cloudwatch.canary_artifact_bucket
   role_arn                 = module.cloudwatch.canary_role_arn


### PR DESCRIPTION
The Concourse CI pipeline has failed with error `CloudFormation Stack update: failed to update CloudFormation stack (UPDATE_ROLLBACK_COMPLETE): ["Resource handler returned message: \"Deprecated runtime version specified`. This is due to a deprecated runtime version `syn-nodejs-puppeteer-3.9` which should be updated to the latest `syn-nodejs-puppeteer-9.0`.
https://ci.platform.aws.chdev.org/teams/team-amido/pipelines/forgerock-cloud-monitoring/jobs/development-apply-chs/builds/193