### PR TITLE
MS1-582 Checkov vulnerability CKV_AWS_364

### DIFF
--- a/terraform/groups/chs/main.tf
+++ b/terraform/groups/chs/main.tf
@@ -15,6 +15,8 @@ data "aws_subnet_ids" "subnets" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 ###
 # Modules
 ###

--- a/terraform/groups/chs/modules/ecs-restart-lambda/iam.tf
+++ b/terraform/groups/chs/modules/ecs-restart-lambda/iam.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_permission" "eventbridge" {
     function_name = aws_lambda_function.restart_function.function_name
     principal = "events.amazonaws.com"
     qualifier = aws_lambda_alias.alias.name
+    source_account = data.aws_caller_identity.current.id
 }
 
 resource "aws_lambda_alias" "alias" {


### PR DESCRIPTION
This PR resolves the Checkov vulnerability CKV_AWS_364. I have added an attribute `source_account` which limits IAM permissions.

Output before changes:

```yaml
Check: CKV_AWS_364: "Ensure that AWS Lambda function permissions delegated to AWS services are limited by SourceArn or SourceAccount"
        FAILED for resource: aws_lambda_permission.eventbridge
        File: \iam.tf:47-53
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-364

                47 | resource "aws_lambda_permission" "eventbridge" {
                48 |     statement_id = "AllowEventBridgeToExecute"
                49 |     action = "lambda:InvokeFunction"
                50 |     function_name = aws_lambda_function.restart_function.function_name
                51 |     principal = "events.amazonaws.com"
                52 |     qualifier = aws_lambda_alias.alias.name
                53 | }
```

Output after changes:
```yaml
Check: CKV_AWS_364: "Ensure that AWS Lambda function permissions delegated to AWS services are limited by SourceArn or SourceAccount"
        PASSED for resource: aws_lambda_permission.eventbridge
        File: \iam.tf:47-54
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-364
```