### PR TITLE
MS1-582 Checkov vulnerability CKV_AWS_290

### DIFF
--- a/terraform/groups/chs/modules/cloudwatch/main.tf
+++ b/terraform/groups/chs/modules/cloudwatch/main.tf
@@ -74,11 +74,23 @@ resource "aws_iam_policy" "canary_role" {
           "logs:CreateLogStream",
           "logs:PutLogEvents",
           "logs:CreateLogGroup",
-          "s3:ListAllMyBuckets",
-          "cloudwatch:PutMetricData",
         ]
         Effect   = "Allow"
-        Resource = "*"
+        Resource = "arn:aws:logs:::*"
+      },
+      {
+        Action = [
+          "s3:ListAllMyBuckets",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:s3:::"
+      },
+      {
+        Action = [
+          "cloudwatch:PutMetricData",
+        ]
+        Effect = "Allow"
+        Resource = "arn:aws:cloudwatch:::"
       },
 
     ]


### PR DESCRIPTION
This PR resolves the Checkov vulnerability CKV_AWS_290. I have added constraints to IAM policies.

Output before changes:
```yaml
Check: CKV_AWS_290: "Ensure IAM policies does not allow write access without constraints"
        FAILED for resource: module.cloudwatch.aws_iam_policy.canary_role
        File: \modules\cloudwatch\main.tf:51-88
        Calling File: \main.tf:23-30
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-290
```

Output after changes:
```yaml
Check: CKV_AWS_290: "Ensure IAM policies does not allow write access without constraints"
        PASSED for resource: aws_iam_policy.canary_role
        File: \main.tf:51-100
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-iam-policies/bc-aws-290
```