### PR TITLE
MS1-582 Checkov vulnerability CKV_AWS_103

### DIFF
--- a/terraform/groups/grafana/main.tf
+++ b/terraform/groups/grafana/main.tf
@@ -40,6 +40,7 @@ module "grafana" {
   service                       = var.service
   ssh_cidrs                     = local.administration_cidrs
   ssh_keyname                   = local.ssh_keyname
+  ssl_policy                   = var.ssl_policy
   subnet_ids                    = local.placement_subnet_ids_by_availability_zone
   user_data_merge_strategy      = var.user_data_merge_strategy
   vpc_id                        = data.aws_vpc.vpc.id

--- a/terraform/groups/grafana/module-grafana/alb.tf
+++ b/terraform/groups/grafana/module-grafana/alb.tf
@@ -58,6 +58,7 @@ resource "aws_lb_listener" "grafana" {
   port              = 443
   protocol          = "HTTPS"
   certificate_arn   = local.certificate_arn
+  ssl_policy        = var.ssl_policy
 
   default_action {
     type             = "forward"

--- a/terraform/groups/grafana/module-grafana/variables.tf
+++ b/terraform/groups/grafana/module-grafana/variables.tf
@@ -153,6 +153,11 @@ variable "ssh_keyname" {
   type        = string
 }
 
+variable "ssl_policy" {
+  description = "The SSL policy version to be used on the ALB"
+  type        = string
+}
+
 variable "subnet_ids" {
   description = "The ids of the subnets into which we'll place instances"
   type        = list(string)

--- a/terraform/groups/grafana/variables.tf
+++ b/terraform/groups/grafana/variables.tf
@@ -93,6 +93,12 @@ variable "service" {
   type        = string
 }
 
+variable "ssl_policy" {
+  default     = "ELBSecurityPolicy-TLS13-1-0-2021-06"
+  description = "The SSL policy version to be used on the ALB"
+  type        = string
+}
+
 variable "team" {
   description = "The team responsible for administering the instance"
   type        = string


### PR DESCRIPTION
This PR resolves the Checkov vulnerability CKV_AWS_103. I have upgraded the SSL policy version on the ALB.

Output before changes:
```yaml
Check: CKV_AWS_103: "Ensure that load balancer is using at least TLS 1.2"
        FAILED for resource: module.grafana.aws_lb_listener.grafana
        File: /module-grafana/alb.tf:57-71
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/bc-aws-general-43
```

Output after changes:
```yaml
Check: CKV_AWS_103: "Ensure that load balancer is using at least TLS 1.2"
        PASSED for resource: module.grafana.aws_lb_listener.grafana
        File: /module-grafana/alb.tf:56-71
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/bc-aws-general-43
```